### PR TITLE
Argo's internal server should be more customizable.

### DIFF
--- a/argo.js
+++ b/argo.js
@@ -112,12 +112,10 @@ Argo.prototype.include = function(mod) {
   return this;
 };
 
-Argo.prototype.listen = function(port) {
-  var app = this.build();
-
-  this._http.createServer(app.run).listen(port);
-
-  return this;
+Argo.prototype.listen = function() {
+	var server = this._http.createServer(this.build().run);
+	server.listen.apply(server, arguments);
+	return this;
 };
 
 Argo.prototype.use = function(middleware) {


### PR DESCRIPTION
Modified Argo.prototype.listen to allow for variable arity.
It will now ignorantly pass through the arguments directly to net.Server.listen as if the method had been invoked directly on an instance of net.Server.

Before, there was no way to pass in more than the port number. This, hopefully, solves that problem.
