### PR TITLE
Add support for all HTTP methods that Node supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,31 @@ $ npm install argo
 * [use(package)](#usepackage)
 * [target](#target)
 * [route](#route)
-* [get](#get)
-* [post](#post)
-* [put](#put)
-* [del](#del)
-* [options](#options)
-* [trace](#trace)
+* Method filters
+  * [get](#get)
+  * [post](#post)
+  * [put](#put)
+  * [head](#head)
+  * [del](#del)
+  * [options](#options)
+  * [trace](#trace)
+  * [copy](#copy)
+  * [lock](#lock)
+  * [mkcol](#mkcol)
+  * [move](#move)
+  * [propfind](#propfind)
+  * [proppatch](#proppatch)
+  * [unlock](#unlock)
+  * [report](#report)
+  * [mkactivity](#mkactivity)
+  * [checkout](#checkout)
+  * [merge](#merge)
+  * [msearch](#msearch)
+  * [notify](#notify)
+  * [subscribe](#subscribe)
+  * [unsubscribe](#unsubscribe)
+  * [patch](#patch)
+  * [search](#search)
 * [map](#map)
 * [include](#include)
 * [listen](#listen)
@@ -185,20 +204,59 @@ argo()
     });
   })
 ```
+
+### Method filters
 <a name="get"/>
 <a name="post"/>
 <a name="put"/>
+<a name="head"/>
 <a name="del"/>
 <a name="options"/>
 <a name="trace"/>
-### get(path, handleFunction)
-### post(path, handleFunction)
-### put(path, handleFunction)
-### del(path, handleFunction)
-### options(path, handleFunction)
-### trace(path, handleFunction)
+<a name="copy"/>
+<a name="lock"/>
+<a name="mkcol"/>
+<a name="move"/>
+<a name="propfind"/>
+<a name="proppatch"/>
+<a name="unlock"/>
+<a name="report"/>
+<a name="mkactivity"/>
+<a name="checkout"/>
+<a name="merge"/>
+<a name="msearch"/>
+<a name="notify"/>
+<a name="subscribe"/>
+<a name="unsubscribe"/>
+<a name="patch"/>
+<a name="search"/>
+#### get(path, handleFunction)
+#### post(path, handleFunction)
+#### put(path, handleFunction)
+#### head(path, handleFunction)
+#### del(path, handleFunction)
+#### options(path, handleFunction)
+#### trace(path, handleFunction)
+#### copy(path, handleFunction)
+#### lock(path, handleFunction)
+#### mkcol(path, handleFunction)
+#### move(path, handleFunction)
+#### propfind(path, handleFunction)
+#### proppatch(path, handleFunction)
+#### unlock(path, handleFunction)
+#### report(path, handleFunction)
+#### mkactivity(path, handleFunction)
+#### checkout(path, handleFunction)
+#### merge(path, handleFunction)
+#### msearch(path, handleFunction)
+#### notify(path, handleFunction)
+#### subscribe(path, handleFunction)
+#### unsubscribe(path, handleFunction)
+#### patch(path, handleFunction)
+#### search(path, handleFunction)
 
-Method filters built on top of `route`.
+Method filters built on top of `route`. `del` and `msearch` correspond to
+the DELETE and M-SEARCH methods, respectively.
 
 Example:
 
@@ -211,6 +269,7 @@ argo()
     });
   })
 ```
+
 <a name="map"/>
 ### map(path, [options], argoSegmentFunction)
 

--- a/argo.js
+++ b/argo.js
@@ -4,6 +4,7 @@ var url = require('url');
 var Stream = require('stream');
 var path = require('path');
 var pipeworks = require('pipeworks');
+var nodemethods = require('methods');
 var environment = require('./environment');
 var Frame = require('./frame');
 var Builder = require('./builder');
@@ -302,15 +303,16 @@ Argo.prototype._routeMap = function(path, options, handleFn) {
   return this;
 };
 
-var methods = {
-  'get': 'GET',
-  'post': 'POST',
-  'put': 'PUT',
-  'del': 'DELETE',
-  'head': 'HEAD',
-  'options': 'OPTIONS',
-  'trace': 'TRACE'
-};
+var methods = {};
+nodemethods.forEach(function(method) {
+  if (method === 'delete') {
+    methods['del'] = 'DELETE';
+  } else if (method === 'm-search') {
+    methods['msearch'] = 'M-SEARCH';
+  } else {
+    methods[method] = method.toUpperCase();
+  }
+});
 
 Object.keys(methods).forEach(function(method) {
   Argo.prototype[method] = function(path, options, handlers) {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "mocha": "~1.8.1"
   },
   "dependencies": {
-    "pipeworks": "1.2.x"
+    "pipeworks": "1.2.x",
+    "methods": "~0.1.0"
   }
 }

--- a/test/argo_test.js
+++ b/test/argo_test.js
@@ -787,123 +787,52 @@ describe('Argo', function() {
     });
   });
 
-  describe('#get', function() {
-    it('responds to a GET request', function(done) {
-      var env = _getEnv();
-      env.request.method = 'GET';
-      env.request.url = '/sheep';
+  // Note: DELETE and M-SEARCH are renamed
+  var methods = {
+    'get': 'GET',
+    'post': 'POST',
+    'put': 'PUT',
+    'head': 'HEAD',
+    'del': 'DELETE',
+    'options': 'OPTIONS',
+    'trace': 'TRACE',
+    'copy': 'COPY',
+    'lock': 'LOCK',
+    'mkcol': 'MKCOL',
+    'move': 'MOVE',
+    'propfind': 'PROPFIND',
+    'proppatch': 'PROPPATCH',
+    'unlock': 'UNLOCK',
+    'report': 'REPORT',
+    'mkactivity': 'MKACTIVITY',
+    'checkout': 'CHECKOUT',
+    'merge': 'MERGE',
+    'msearch': 'M-SEARCH',
+    'notify': 'NOTIFY',
+    'subscribe': 'SUBSCRIBE',
+    'unsubscribe': 'UNSUBSCRIBE',
+    'patch': 'PATCH',
+    'search': 'SEARCH'
+  };
 
-      argo()
-        .get('^/sheep$', function(handle) {
-          handle('request', function(env, next) {
-            assert.equal(env.request.method, 'GET');
-            done();
-          });
-        })
-        .call(env);
-    });
-  });
+  Object.keys(methods).forEach(function(methodProp) {
+    var httpMethod = methods[methodProp];
 
-  describe('#post', function() {
-    it('responds to a POST request', function(done) {
-      var env = _getEnv();
-      env.request.method = 'POST';
-      env.request.url = '/sheep';
+    describe('#' + methodProp, function() {
+      it('responds to a ' + httpMethod + ' request', function(done) {
+        var env = _getEnv();
+        env.request.method = httpMethod;
+        env.request.url = '/sheep';
 
-      argo()
-        .post('^/sheep$', function(handle) {
-          handle('request', function(env, next) {
-            assert.equal(env.request.method, 'POST');
-            done();
-          });
-        })
-        .call(env);
-    });
-  });
-
-  describe('#put', function() {
-    it('responds to a PUT request', function(done) {
-      var env = _getEnv();
-      env.request.method = 'PUT';
-      env.request.url = '/sheep';
-
-      argo()
-        .put('^/sheep$', function(handle) {
-          handle('request', function(env, next) {
-            assert.equal(env.request.method, 'PUT');
-            done();
-          });
-        })
-        .call(env);
-    });
-  });
-
-  describe('#del', function() {
-    it('responds to a DELETE request', function(done) {
-      var env = _getEnv();
-      env.request.method = 'DELETE';
-      env.request.url = '/sheep';
-
-      argo()
-        .del('^/sheep$', function(handle) {
-          handle('request', function(env, next) {
-            assert.equal(env.request.method, 'DELETE');
-            done();
-          });
-        })
-        .call(env);
-    });
-  });
-  
-  describe('#head', function() {
-    it('responds to a HEAD request', function(done) {
-      var env = _getEnv();
-      env.request.method = 'HEAD';
-      env.request.url = '/sheep';
-
-      argo()
-        .head('^/sheep$', function(handle) {
-          handle('request', function(env, next) {
-            assert.equal(env.request.method, 'HEAD');
-            done();
-          });
-        })
-        .call(env);
-    });
-  });
-
-  describe('#options', function() {
-    it('responds to a OPTIONS request', function(done) {
-      var env = _getEnv();
-      env.request.method = 'OPTIONS';
-      env.request.url = '/sheep';
-
-      argo()
-        .options('^/sheep$', function(handle) {
-          handle('request', function(env, next) {
-            assert.equal(env.request.method, 'OPTIONS');
-            done();
-          });
-        })
-        .call(env);
-    });
-  });
-
-
-  describe('#trace', function() {
-    it('responds to a TRACE request', function(done) {
-      var env = _getEnv();
-      env.request.method = 'TRACE';
-      env.request.url = '/sheep';
-
-      argo()
-        .trace('^/sheep$', function(handle) {
-          handle('request', function(env, next) {
-            assert.equal(env.request.method, 'TRACE');
-            done();
-          });
-        })
-        .call(env);
+        argo()
+          [methodProp]('^/sheep$', function(handle) {
+            handle('request', function(env, next) {
+              assert.equal(env.request.method, httpMethod);
+              done();
+            });
+          })
+          .call(env);
+      });
     });
   });
 


### PR DESCRIPTION
I wanted to add support for PATCH, but ended up implementing all of them. Overkill?
